### PR TITLE
fix gitignore syntax

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -28,8 +28,8 @@ coverage
 build/Release
 
 # Dependency directories
-node_modules
-jspm_packages
+node_modules/
+jspm_packages/
 
 # Optional npm cache directory
 .npm


### PR DESCRIPTION
Some .gitignore parsers interpret directory vs non-directory patterns strictly (e.g. monochromegane/go-gitignore), so a `node_modules` pattern would not necessarily match against a real `node_modules` directory. It's generally safe to add a trailing slash to directory .gitignore patterns.

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:** 

_TODO_

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
